### PR TITLE
[Refactor] 메인메뉴, 회원가입, 레이아웃 리팩토링 진행

### DIFF
--- a/src/components/atoms/button/Button.tsx
+++ b/src/components/atoms/button/Button.tsx
@@ -26,7 +26,7 @@ interface ButtonProps {
   shadow?: boolean;
   type: 'button' | 'submit';
   icon?: SvgIconComponent;
-  disalbed?: boolean;
+  disabled?: boolean;
   onClick?: () => void;
 }
 
@@ -38,7 +38,7 @@ const Button = ({
   shadow = false,
   type,
   icon,
-  disalbed = false,
+  disabled = false,
   ...props
 }: ButtonProps) => {
   const neumorphism = shadow ? 'button--shadow' : '';
@@ -52,7 +52,7 @@ const Button = ({
         `button--${radius}`,
         neumorphism,
       ].join(' ')}
-      disabled={disalbed}
+      disabled={disabled}
       {...props}
     >
       {icon && (

--- a/src/components/atoms/dropdown/DropdownItem.scss
+++ b/src/components/atoms/dropdown/DropdownItem.scss
@@ -2,25 +2,21 @@
 @import '../../../styles/fonts';
 
 .dropdown__item {
-  padding: 20px 30px;
+  display: flex;
   cursor: pointer;
-  // width: 100%;
-  // text-align: center;
+  justify-content: center;
+  padding: 16px 0px;
   font-size: 20px;
   font-weight: 600;
   background-color: transparent;
   color: $main-text-color;
   border: none;
-  // outline: none;
-  // border-bottom: 1px solid $shadow-color;
 
   &:hover {
     color: $secondary-theme-color;
-    // border-bottom: 1px solid $secondary-theme-color;
   }
 
   &:last-child {
     border-bottom: none;
-    // border-radius: 0 0 10px 10px;
   }
 }

--- a/src/components/atoms/dropdown/DropdownItem.scss
+++ b/src/components/atoms/dropdown/DropdownItem.scss
@@ -16,7 +16,7 @@
 
   &:hover {
     color: $secondary-theme-color;
-    border-bottom: 1px solid $secondary-theme-color;
+    // border-bottom: 1px solid $secondary-theme-color;
   }
 
   &:last-child {

--- a/src/components/atoms/dropdown/DropdownItem.scss
+++ b/src/components/atoms/dropdown/DropdownItem.scss
@@ -1,25 +1,26 @@
-@import 'styles/variables';
-@import 'styles/fonts';
+@import '../../../styles/variables';
+@import '../../../styles/fonts';
 
 .dropdown__item {
-  padding: 10px 30px;
+  padding: 20px 30px;
   cursor: pointer;
-  width: 100%;
-  text-align: center;
+  // width: 100%;
+  // text-align: center;
   font-size: 20px;
   font-weight: 600;
   background-color: transparent;
   color: $main-text-color;
   border: none;
-  outline: none;
-  border-bottom: 1px solid $shadow-color;
+  // outline: none;
+  // border-bottom: 1px solid $shadow-color;
 
   &:hover {
-    background-color: #f2f2f2;
+    color: $secondary-theme-color;
+    border-bottom: 1px solid $secondary-theme-color;
   }
 
   &:last-child {
     border-bottom: none;
-    border-radius: 0 0 10px 10px;
+    // border-radius: 0 0 10px 10px;
   }
 }

--- a/src/components/atoms/text/Text.scss
+++ b/src/components/atoms/text/Text.scss
@@ -7,7 +7,6 @@
 
   &__main-title {
     font-size: 30px;
-    margin-bottom: 10px;
   }
   &__main-content {
     font-size: 18px;

--- a/src/components/atoms/text/Text.scss
+++ b/src/components/atoms/text/Text.scss
@@ -45,6 +45,9 @@
   &--neutral {
     color: #acacac;
   }
+  &--light {
+    color: $white;
+  }
   &--summary {
     color: $placeholder-color;
   }

--- a/src/components/atoms/text/Text.scss
+++ b/src/components/atoms/text/Text.scss
@@ -25,6 +25,12 @@
     font-size: 15px;
     cursor: pointer;
   }
+  &__highlight {
+    font-size: 24px;
+  }
+  &__detail {
+    font-size: 12px;
+  }
   &--primary {
     color: $main-text-color;
   }
@@ -39,6 +45,9 @@
   }
   &--neutral {
     color: #acacac;
+  }
+  &--summary {
+    color: $placeholder-color;
   }
   &--underline {
     text-decoration: underline;

--- a/src/components/atoms/text/Text.tsx
+++ b/src/components/atoms/text/Text.tsx
@@ -12,7 +12,7 @@ interface TextProps {
     | 'link'
     | 'highlight'
     | 'detail';
-  color?: 'primary' | 'success' | 'danger' | 'link-color' | 'neutral';
+  color?: 'primary' | 'success' | 'danger' | 'link-color' | 'neutral' | 'light';
   bold?: boolean;
   underline?: boolean;
   remainingTime?: number;

--- a/src/components/atoms/text/Text.tsx
+++ b/src/components/atoms/text/Text.tsx
@@ -3,7 +3,15 @@ import './Text.scss';
 
 interface TextProps {
   content?: string;
-  type: 'main-title' | 'main-content' | 'title' | 'subtitle' | 'info' | 'link';
+  type:
+    | 'main-title'
+    | 'main-content'
+    | 'title'
+    | 'subtitle'
+    | 'info'
+    | 'link'
+    | 'highlight'
+    | 'detail';
   color?: 'primary' | 'success' | 'danger' | 'link-color' | 'neutral';
   bold?: boolean;
   underline?: boolean;

--- a/src/components/molecules/dropdown/Dropdown.scss
+++ b/src/components/molecules/dropdown/Dropdown.scss
@@ -4,7 +4,7 @@
   &-list {
     position: absolute;
     display: flex;
-    padding-top: 25px;
+    padding-top: 20px;
     top: 130%;
     left: 50%;
     transform: translateX(-50%);

--- a/src/components/molecules/dropdown/Dropdown.scss
+++ b/src/components/molecules/dropdown/Dropdown.scss
@@ -2,14 +2,10 @@
 
 .header__dropdown {
   &-list {
-    position: absolute;
     display: flex;
-    padding-top: 20px;
-    top: 130%;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 180px;
+    position: absolute;
     flex-direction: column;
+    width: 180px;
     background-color: rgba($white, 0.7);
     border-radius: 0 0 10px 10px;
   }

--- a/src/components/molecules/profiledetail/ProfileDropdown.scss
+++ b/src/components/molecules/profiledetail/ProfileDropdown.scss
@@ -3,43 +3,33 @@
 
 .profile-dropdown {
   &__container {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    align-items: center;
     cursor: default;
     position: absolute;
-    top: 200%; // Profile 컴포넌트 바로 아래에 위치
+    top: 200%;
     transform: translateX(-60%);
     background-color: $white;
     border: 1px solid #ccc;
     border-radius: 10px;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-    width: 250px;
-    height: 350px;
-
-    display: flex;
-    flex-direction: column;
-    justify-content: space-evenly; // 세로 중앙 정렬
-    align-items: center; // 가로 중앙 정렬
-    padding: 20px; // 내부 여백 추가
-  }
-
-  &__header {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-    margin-bottom: 20px;
   }
 
   &__buttons {
     display: flex;
     align-items: center;
+    margin: 20px;
     flex-direction: column;
     gap: 20px;
   }
 
   &__close {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    padding: 0;
+    padding-top: 10px;
+    display: flex;
+    width: 90%;
+    justify-content: flex-end;
+    cursor: pointer;
   }
 }

--- a/src/components/molecules/profiledetail/ProfileDropdown.scss
+++ b/src/components/molecules/profiledetail/ProfileDropdown.scss
@@ -4,13 +4,14 @@
 .profile-dropdown {
   &__container {
     display: flex;
+    width: 300%;
     flex-direction: column;
     justify-content: space-evenly;
     align-items: center;
     cursor: default;
     position: absolute;
-    top: 200%;
-    transform: translateX(-60%);
+    top: calc(100% + 10px);
+    right: -60px;
     background-color: $white;
     border: 1px solid #ccc;
     border-radius: 10px;
@@ -20,7 +21,8 @@
   &__buttons {
     display: flex;
     align-items: center;
-    margin: 20px;
+    width: 30%;
+    padding: 20px 0;
     flex-direction: column;
     gap: 20px;
   }
@@ -29,7 +31,7 @@
     padding-top: 10px;
     display: flex;
     width: 90%;
-    justify-content: flex-end;
+    justify-content: end;
     cursor: pointer;
   }
 }

--- a/src/components/molecules/profiledetail/ProfileDropdown.tsx
+++ b/src/components/molecules/profiledetail/ProfileDropdown.tsx
@@ -51,11 +51,9 @@ const ProfileDropdown = ({
       <div className="profile-dropdown__close">
         <CloseIcon onClick={onClose} fontSize="medium" />
       </div>
-      <div className="profile-detail__header">
-        <Profile arrangement="vertical" userName={userName} />
-        <div className="profile-dropdown__info">
-          <Text content={userId} type="info" color="neutral" />
-        </div>
+      <Profile arrangement="vertical" userName={userName} />
+      <div className="profile-dropdown__info">
+        <Text content={userId} type="info" color="neutral" />
       </div>
       <div className="profile-dropdown__buttons">
         <Button

--- a/src/components/organisms/footer/Footer.scss
+++ b/src/components/organisms/footer/Footer.scss
@@ -2,21 +2,25 @@
 @import '../../../styles/variables';
 
 .footer {
-  width: 100%;
-  height: 200px;
   background-color: $white;
 
   &__container {
     display: flex;
-    flex-direction: column;
-    align-items: start;
+    width: 100%;
+    padding: 13px 0;
+    align-items: center;
+    justify-content: center;
     text-align: start;
-    margin: 50px 100px;
   }
   &__logo {
-    width: 240px;
-    height: 200px;
-    background-image: url('../../../assets/images/semo_logo_footer.svg');
-    background-repeat: no-repeat;
+    display: flex;
+    width: 5%;
+    img {
+      width: 60px;
+      height: auto;
+    }
+  }
+  &__content {
+    width: 88%;
   }
 }

--- a/src/components/organisms/footer/Footer.tsx
+++ b/src/components/organisms/footer/Footer.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
 import './Footer.scss';
 import Text from 'components/atoms/text/Text';
+import logo from 'assets/images/semo_logo_footer.svg';
 
 export const Footer = () => {
   const content =
-    '10:00 ~ 18:00 (점심 시간 13:00 ~ 14:00 ) \n 주일, 공유일 휴무';
+    '운영시간 : 10:00 ~ 18:00 (점심 시간 13:00 ~ 14:00) \n 주일, 공유일 휴무';
+  const copyright = 'Copyright ⓒ 2024. All rights reserved.';
   return (
     <div className="footer__container">
-      <div className="footer__logo" />
-      <Text content={content} type="info" color="neutral" />
+      <div className="footer__logo">
+        <img src={logo} alt="logo" />
+      </div>
+      <div className="footer__content">
+        <Text content={content} type="info" color="neutral" />
+        <Text content={copyright} type="info" color="neutral" />
+      </div>
     </div>
   );
 };

--- a/src/components/organisms/header/Header.scss
+++ b/src/components/organisms/header/Header.scss
@@ -9,7 +9,8 @@
     justify-content: space-between;
     align-items: center;
     height: 4vh;
-    padding: 15px 30px;
+    // padding: 15px 30px;
+    padding: 0.8% 1.6%;
   }
 
   &__logo {
@@ -36,12 +37,12 @@
       }
     }
     &-dropdown {
-      display: flex;
-      // display: none;
+      // display: flex;
+      display: none;
       position: relative;
-      // &:hover {
-      //   display: flex;
-      // }
+      &:hover {
+        display: flex;
+      }
     }
   }
 

--- a/src/components/organisms/header/Header.scss
+++ b/src/components/organisms/header/Header.scss
@@ -6,32 +6,35 @@
 
   &__container {
     display: flex;
-    width: 100%;
-    justify-content: space-between;
+    justify-content: space-around;
+    height: 8vh;
     align-items: center;
   }
 
   &__logo {
-    padding: 20px 35px;
+    // padding: 20px 0;
   }
 
   &__menu {
     display: flex;
     align-items: center;
-    width: 70%;
+    width: 65%;
     gap: 110px;
 
-    &-item {
+    &__item {
       position: relative;
       cursor: pointer;
-
+      width: 180px;
+      .text {
+        padding: 20px 0;
+      }
       &:hover {
-        .header__menu-dropdown {
+        .header__menu__dropdown {
           display: flex;
         }
       }
     }
-    &-dropdown {
+    &__dropdown {
       display: none;
       position: relative;
       &:hover {
@@ -43,7 +46,6 @@
   &__profile {
     position: relative;
     display: flex;
-    width: 8%;
     cursor: pointer;
   }
 }

--- a/src/components/organisms/header/Header.scss
+++ b/src/components/organisms/header/Header.scss
@@ -2,17 +2,16 @@
 @import '../../../styles/variables';
 
 .header {
-  background-color: $white;
+  width: 100%;
 
   &__container {
     display: flex;
+    position: sticky;
+    background-color: $white;
+    top: 0;
     justify-content: space-around;
-    height: 8vh;
+    height: 5.2vh;
     align-items: center;
-  }
-
-  &__logo {
-    // padding: 20px 0;
   }
 
   &__menu {
@@ -21,12 +20,16 @@
     width: 65%;
     gap: 110px;
 
+    &__home {
+      cursor: pointer;
+    }
+
     &__item {
       position: relative;
       cursor: pointer;
       width: 180px;
       .text {
-        padding: 20px 0;
+        padding: 13px 0;
       }
       &:hover {
         .header__menu__dropdown {

--- a/src/components/organisms/header/Header.scss
+++ b/src/components/organisms/header/Header.scss
@@ -6,25 +6,20 @@
 
   &__container {
     display: flex;
+    width: 100%;
     justify-content: space-between;
     align-items: center;
-    height: 4vh;
-    // padding: 15px 30px;
-    padding: 0.8% 1.6%;
   }
 
   &__logo {
-    width: 150px;
-    height: 40px;
-    background-image: url('../../../assets/images/semo_logo_header.svg');
-    background-repeat: no-repeat;
+    padding: 20px 35px;
   }
 
   &__menu {
     display: flex;
     align-items: center;
     width: 70%;
-    gap: 100px;
+    gap: 110px;
 
     &-item {
       position: relative;
@@ -37,7 +32,6 @@
       }
     }
     &-dropdown {
-      // display: flex;
       display: none;
       position: relative;
       &:hover {
@@ -48,10 +42,8 @@
 
   &__profile {
     position: relative;
-    cursor: pointer;
-  }
-  &__auth {
     display: flex;
-    gap: 40px;
+    width: 8%;
+    cursor: pointer;
   }
 }

--- a/src/components/organisms/header/Header.scss
+++ b/src/components/organisms/header/Header.scss
@@ -8,8 +8,8 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    height: 6vh;
-    padding: 0.7% 30px;
+    height: 4vh;
+    padding: 15px 30px;
   }
 
   &__logo {
@@ -22,8 +22,8 @@
   &__menu {
     display: flex;
     align-items: center;
+    width: 70%;
     gap: 100px;
-    margin-right: 60%;
 
     &-item {
       position: relative;
@@ -36,11 +36,12 @@
       }
     }
     &-dropdown {
-      display: none;
+      display: flex;
+      // display: none;
       position: relative;
-      &:hover {
-        display: flex;
-      }
+      // &:hover {
+      //   display: flex;
+      // }
     }
   }
 

--- a/src/components/organisms/header/Header.tsx
+++ b/src/components/organisms/header/Header.tsx
@@ -6,15 +6,16 @@ import Profile from 'components/molecules/profile/Profile';
 import ProfileDetail from 'components/molecules/profiledetail/ProfileDropdown';
 import Text from 'components/atoms/text/Text';
 import Button from 'components/atoms/button/Button';
+import logo from '../../../assets/images/semo_logo_header.svg';
 
 const Header = () => {
   // const token = localStorage.getItem('token');
   // 테스트용 임시 토큰 - true, false 로 테스트!
-  const token = false;
+  const token = true;
   // const userRole = jwt토큰 decode 진행해서 얻기;
   // 테스트용 임시 유저 권한 - super, admin, user 로 테스트!
-  type UserRole = 'super' | 'admin' | 'user';
-  const userRole: UserRole = 'super';
+  type UserRole = 'ROLE_SUPER' | 'ROLE_ADMIN' | 'ROLE_USER';
+  const userRole: UserRole = 'ROLE_SUPER';
   const [isProfileDetailOpen, setIsProfileDetailOpen] = useState(false);
   // 테스트용 임시 유저 이름
   const userName = '태연님';
@@ -27,7 +28,7 @@ const Header = () => {
       label: 'DB관리',
       route: '/database-management',
     },
-    ...(userRole === 'super'
+    ...(userRole === 'ROLE_SUPER'
       ? [
           {
             label: '요청 관리',
@@ -49,14 +50,14 @@ const Header = () => {
   const handleHomeClick = () => {
     let homePath;
     switch (userRole as UserRole) {
-      case 'super':
-        homePath = '/super-home';
+      case 'ROLE_SUPER':
+        homePath = '/';
         break;
-      case 'admin':
-        homePath = '/admin-home';
+      case 'ROLE_ADMIN':
+        homePath = '/';
         break;
-      case 'user':
-        homePath = '/user-home';
+      case 'ROLE_USER':
+        homePath = '/';
         break;
       default:
         homePath = '/';
@@ -66,7 +67,7 @@ const Header = () => {
 
   return (
     <div className="header__container">
-      <div className="header__logo" />
+      <img src={logo} alt="Logo" className="header__logo" />
       {token ? (
         <>
           <div className="header__menu">
@@ -77,7 +78,7 @@ const Header = () => {
             >
               <Text content="홈" type="subtitle" bold />
             </div>
-            {(userRole === 'super' || userRole === 'admin') && (
+            {(userRole === 'ROLE_SUPER' || userRole === 'ROLE_ADMIN') && (
               <div className="header__menu-item">
                 <Text content="관리자 메뉴" type="subtitle" bold />
                 <div className="header__menu-dropdown">

--- a/src/components/organisms/header/Header.tsx
+++ b/src/components/organisms/header/Header.tsx
@@ -72,8 +72,8 @@ const Header = () => {
         <>
           <div className="header__menu">
             <div
+              className="header__menu__home"
               onClick={handleHomeClick}
-              style={{ cursor: 'pointer' }}
               role="presentation"
             >
               <Text content="홈" type="subtitle" bold />

--- a/src/components/organisms/header/Header.tsx
+++ b/src/components/organisms/header/Header.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Dropdown from 'components/molecules/dropdown/Dropdown';
 import './Header.scss';
@@ -6,7 +6,7 @@ import Profile from 'components/molecules/profile/Profile';
 import ProfileDetail from 'components/molecules/profiledetail/ProfileDropdown';
 import Text from 'components/atoms/text/Text';
 import Button from 'components/atoms/button/Button';
-import logo from '../../../assets/images/semo_logo_header.svg';
+import logo from 'assets/images/semo_logo_header.svg';
 
 const Header = () => {
   // const token = localStorage.getItem('token');
@@ -79,9 +79,9 @@ const Header = () => {
               <Text content="홈" type="subtitle" bold />
             </div>
             {(userRole === 'ROLE_SUPER' || userRole === 'ROLE_ADMIN') && (
-              <div className="header__menu-item">
+              <div className="header__menu__item">
                 <Text content="관리자 메뉴" type="subtitle" bold />
-                <div className="header__menu-dropdown">
+                <div className="header__menu__dropdown">
                   <Dropdown items={items} />
                 </div>
               </div>

--- a/src/components/organisms/modal/CompanyRegister.scss
+++ b/src/components/organisms/modal/CompanyRegister.scss
@@ -1,15 +1,9 @@
 @import '../../../styles/variables';
 .company-register {
-  display: flex;
-  flex-direction: column;
-
   &__container {
     display: flex;
     position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    inset: 0;
     background-color: rgba(0, 0, 0, 0.5);
     align-items: center;
     justify-content: center;
@@ -17,30 +11,32 @@
 
   &__content {
     background-color: $main-theme-color;
-    padding: 30px;
     border-radius: 20px;
-    width: 620px;
-    height: 550px;
+    padding: 30px;
   }
 
   &__text-group {
-    align-items: center;
     text-align: start;
-    margin: 30px 50px;
+    width: 70%;
+    padding: 20px 40px;
   }
 
   &__form {
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-top: 50px;
-    margin-bottom: 60px;
+    padding: 30px;
     gap: 20px;
   }
 
   &__button-group {
+    padding: 30px;
     display: flex;
     justify-content: center;
     gap: 30px;
+  }
+  &__email-auth__warning {
+    position: absolute;
+    text-align: start;
   }
 }

--- a/src/components/organisms/modal/CompanyRegister.scss
+++ b/src/components/organisms/modal/CompanyRegister.scss
@@ -1,42 +1,54 @@
 @import '../../../styles/variables';
 .company-register {
-  &__container {
-    position: fixed;
-    inset: 0;
-    background-color: rgba(0, 0, 0, 0.5);
+  &__background {
     display: flex;
+    position: fixed;
+    width: 100%;
+    height: 100%;
     align-items: center;
     justify-content: center;
+    background-color: rgba(0, 0, 0, 0.5);
   }
 
-  &__content {
+  &__container {
     display: flex;
+    width: 35%;
+    align-items: center;
     flex-direction: column;
     justify-content: space-between;
     background-color: $main-theme-color;
     border-radius: 50px;
-    padding: 60px;
-    gap: 30px;
+    padding: 60px 0;
+    gap: 50px;
   }
 
-  &__text-group {
-    text-align: start;
+  &__header {
+    display: flex;
+    width: 75%;
+    height: 30%;
+    flex-direction: column;
+    align-items: start;
+    gap: 10px;
   }
 
   &__form {
     display: flex;
+    position: relative;
     flex-direction: column;
     align-items: center;
-    gap: 20px;
+    gap: 15px;
+
+    &__email__warning,
+    &__tax-id__warning {
+      position: absolute;
+      text-align: start;
+    }
   }
 
   &__button-group {
     display: flex;
     justify-content: center;
+    align-items: center;
     gap: 30px;
-  }
-  &__email-auth__warning {
-    position: absolute;
-    text-align: start;
   }
 }

--- a/src/components/organisms/modal/CompanyRegister.scss
+++ b/src/components/organisms/modal/CompanyRegister.scss
@@ -1,36 +1,36 @@
 @import '../../../styles/variables';
 .company-register {
   &__container {
-    display: flex;
     position: fixed;
     inset: 0;
     background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
     align-items: center;
     justify-content: center;
   }
 
   &__content {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
     background-color: $main-theme-color;
-    border-radius: 20px;
-    padding: 30px;
+    border-radius: 50px;
+    padding: 60px;
+    gap: 30px;
   }
 
   &__text-group {
     text-align: start;
-    width: 70%;
-    padding: 20px 40px;
   }
 
   &__form {
     display: flex;
     flex-direction: column;
     align-items: center;
-    padding: 30px;
     gap: 20px;
   }
 
   &__button-group {
-    padding: 30px;
     display: flex;
     justify-content: center;
     gap: 30px;

--- a/src/components/organisms/modal/CompanyRegister.tsx
+++ b/src/components/organisms/modal/CompanyRegister.tsx
@@ -19,6 +19,7 @@ interface CompanyData {
 const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
   const emailRegEx =
     /^[A-Za-z0-9]([-_.]?[A-Za-z0-9])*@[A-Za-z0-9]([-_.]?[A-Za-z0-9])*\.[A-Za-z]{2,3}$/i;
+  const taxIdRegEx = /^\d{3}-\d{2}-\d{5}$/;
 
   const [formData, setFormData] = useState<CompanyData>({
     email: '',
@@ -28,6 +29,7 @@ const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
   });
 
   const [emailValid, setEmailValid] = useState(false);
+  const [taxIdValid, setTaxIdValid] = useState(false);
 
   if (!isOpen) return null;
 
@@ -44,6 +46,16 @@ const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
     setFormData((prev) => ({ ...prev, email: emailValue })); // formData 업데이트
     setEmailValid(emailRegEx.test(emailValue)); // 정규식 검사
   };
+  const taxIdHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const taxIdValue = e.target.value;
+    const formattedValue = taxIdValue
+      .replace(/[^\d-]/g, '')
+      .replace(/^(\d{3})(\d{2})(\d{5})$/, '$1-$2-$3')
+      .slice(0, 12);
+
+    setFormData((prev) => ({ ...prev, taxId: formattedValue }));
+    setTaxIdValid(taxIdRegEx.test(formattedValue));
+  };
 
   const handleSubmit = async () => {
     // TODO : axios 인터페이스 설정 시 해당 요청 api 연결
@@ -58,24 +70,24 @@ const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
   };
 
   return (
-    <div className="company-register__container">
-      <div className="company-register__content">
-        <div className="company-register__text-group">
+    <div className="company-register__background">
+      <div className="company-register__container">
+        <div className="company-register__header">
           <Text content="Company Registration" type="title" />
           <Text content="회사 등록" type="subtitle" />
         </div>
         <div className="company-register__form">
-          <Input
-            type="email"
-            placeholder="연락처(이메일)"
-            value={formData.email}
-            onChange={emailHandler} // 이메일 입력 시 정규식 검사
-            size="large"
-            shape="line"
-          />
-          {formData.email &&
-            !emailValid && ( // emailValid가 false일 때 경고 메시지 출력
-              <div className="company-register__email-auth__warning">
+          <div className="company-register__form__email">
+            <Input
+              type="email"
+              placeholder="연락처(이메일)"
+              value={formData.email}
+              onChange={emailHandler}
+              size="large"
+              shape="line"
+            />
+            {formData.email && !emailValid && (
+              <div className="company-register__form__email__warning">
                 <Text
                   content="올바른 이메일 형식이 아닙니다."
                   type="info"
@@ -83,6 +95,7 @@ const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
                 />
               </div>
             )}
+          </div>
           <Input
             type="text"
             placeholder="회사명"
@@ -91,14 +104,25 @@ const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
             size="large"
             shape="line"
           />
-          <Input
-            type="text"
-            placeholder="사업자 등록번호"
-            value={formData.taxId}
-            onChange={handleInputChange('taxId')}
-            size="large"
-            shape="line"
-          />
+          <div className="company-register__form__tax-id">
+            <Input
+              type="text"
+              placeholder="사업자 등록번호"
+              value={formData.taxId}
+              onChange={taxIdHandler}
+              size="large"
+              shape="line"
+            />
+            {formData.taxId && !taxIdValid && (
+              <div className="company-register__form__tax-id__warning">
+                <Text
+                  content="올바른 사업자 등록번호 형식이 아닙니다."
+                  type="info"
+                  color="danger"
+                />
+              </div>
+            )}
+          </div>
           <Input
             type="text"
             placeholder="성명"
@@ -126,7 +150,7 @@ const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
             radius="oval"
             shadow
             onClick={handleSubmit}
-            disabled={!emailValid}
+            disabled={!emailValid || !taxIdValid}
           />
         </div>
       </div>

--- a/src/components/organisms/modal/CompanyRegister.tsx
+++ b/src/components/organisms/modal/CompanyRegister.tsx
@@ -17,12 +17,17 @@ interface CompanyData {
 }
 
 const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
+  const emailRegEx =
+    /^[A-Za-z0-9]([-_.]?[A-Za-z0-9])*@[A-Za-z0-9]([-_.]?[A-Za-z0-9])*\.[A-Za-z]{2,3}$/i;
+
   const [formData, setFormData] = useState<CompanyData>({
     email: '',
     companyName: '',
     taxId: '',
     ownerName: '',
   });
+
+  const [emailValid, setEmailValid] = useState(false);
 
   if (!isOpen) return null;
 
@@ -34,9 +39,21 @@ const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
       }));
     };
 
+  const emailHandler = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const emailValue = e.target.value; // 입력값을 변수에 저장
+    setFormData((prev) => ({ ...prev, email: emailValue })); // formData 업데이트
+    setEmailValid(emailRegEx.test(emailValue)); // 정규식 검사
+  };
+
   const handleSubmit = async () => {
     // TODO : axios 인터페이스 설정 시 해당 요청 api 연결
     console.log('입력된 데이터:', formData);
+    setFormData({
+      email: '',
+      companyName: '',
+      taxId: '',
+      ownerName: '',
+    });
     onClose();
   };
 
@@ -48,14 +65,26 @@ const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
           <Text content="회사 등록" type="subtitle" />
         </div>
         <div className="company-register__form">
-          <Input
-            type="email"
-            placeholder="연락처(이메일)"
-            value={formData.email}
-            onChange={handleInputChange('email')}
-            size="large"
-            shape="line"
-          />
+          <div className="test">
+            <Input
+              type="email"
+              placeholder="연락처(이메일)"
+              value={formData.email}
+              onChange={emailHandler} // 이메일 입력 시 정규식 검사
+              size="large"
+              shape="line"
+            />
+            {formData.email &&
+              !emailValid && ( // emailValid가 false일 때 경고 메시지 출력
+                <div className="company-register__email-auth__warning">
+                  <Text
+                    content="올바른 이메일 형식이 아닙니다."
+                    type="info"
+                    color="danger"
+                  />
+                </div>
+              )}
+          </div>
           <Input
             type="text"
             placeholder="회사명"
@@ -93,12 +122,13 @@ const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
           />
           <Button
             size="large"
-            type="button"
+            type="submit"
             label="COMPLETE"
             color="primary"
             radius="oval"
             shadow
             onClick={handleSubmit}
+            disabled={!emailValid}
           />
         </div>
       </div>

--- a/src/components/organisms/modal/CompanyRegister.tsx
+++ b/src/components/organisms/modal/CompanyRegister.tsx
@@ -65,26 +65,24 @@ const CompanyRegister = ({ isOpen, onClose }: CompanyRegisterProps) => {
           <Text content="회사 등록" type="subtitle" />
         </div>
         <div className="company-register__form">
-          <div className="test">
-            <Input
-              type="email"
-              placeholder="연락처(이메일)"
-              value={formData.email}
-              onChange={emailHandler} // 이메일 입력 시 정규식 검사
-              size="large"
-              shape="line"
-            />
-            {formData.email &&
-              !emailValid && ( // emailValid가 false일 때 경고 메시지 출력
-                <div className="company-register__email-auth__warning">
-                  <Text
-                    content="올바른 이메일 형식이 아닙니다."
-                    type="info"
-                    color="danger"
-                  />
-                </div>
-              )}
-          </div>
+          <Input
+            type="email"
+            placeholder="연락처(이메일)"
+            value={formData.email}
+            onChange={emailHandler} // 이메일 입력 시 정규식 검사
+            size="large"
+            shape="line"
+          />
+          {formData.email &&
+            !emailValid && ( // emailValid가 false일 때 경고 메시지 출력
+              <div className="company-register__email-auth__warning">
+                <Text
+                  content="올바른 이메일 형식이 아닙니다."
+                  type="info"
+                  color="danger"
+                />
+              </div>
+            )}
           <Input
             type="text"
             placeholder="회사명"

--- a/src/components/organisms/welcome/Welcome.scss
+++ b/src/components/organisms/welcome/Welcome.scss
@@ -5,9 +5,9 @@
   &__content {
     display: flex;
     justify-content: space-between;
-    width: 74%;
+    width: 75%;
     height: 60%;
-    padding: 40px;
+    padding: 60px;
     background-color: $main-theme-color;
     border-radius: 20px;
     box-shadow:
@@ -17,14 +17,20 @@
   &__text-group {
     display: flex;
     flex-direction: column;
-    text-align: left;
     justify-content: center;
   }
+  &__start,
+  &__quality {
+    text-align: left;
+    &__title {
+      padding: 10px 0;
+    }
+  }
+
   &__button-group {
     display: flex;
-    width: 32%;
-    justify-content: center;
     flex-direction: column;
+    justify-content: center;
     gap: 100px;
   }
 }

--- a/src/components/organisms/welcome/Welcome.scss
+++ b/src/components/organisms/welcome/Welcome.scss
@@ -5,8 +5,8 @@
   &__content {
     display: flex;
     justify-content: space-between;
-    width: 1400px;
-    height: 600px;
+    width: 74%;
+    height: 60%;
     padding: 40px;
     background-color: $main-theme-color;
     border-radius: 20px;
@@ -22,9 +22,9 @@
   }
   &__button-group {
     display: flex;
+    width: 32%;
     justify-content: center;
     flex-direction: column;
-    padding-right: 40px;
     gap: 100px;
   }
 }

--- a/src/components/organisms/welcome/Welcome.tsx
+++ b/src/components/organisms/welcome/Welcome.tsx
@@ -26,10 +26,22 @@ const Welcome = () => {
   return (
     <div className="welcome__content">
       <div className="welcome__text-group">
-        <Text content={title} type="main-title" />
-        <Text content={content} type="main-content" />
-        <Text content={title2} type="main-title" />
-        <Text content={content2} type="main-content" />
+        <div className="welcome__start">
+          <div className="welcome__start__title">
+            <Text content={title} type="main-title" />
+          </div>
+          <div className="welcome__start__content">
+            <Text content={content} type="main-content" />
+          </div>
+        </div>
+        <div className="welcome__quality">
+          <div className="welcome__quality__title">
+            <Text content={title2} type="main-title" />
+          </div>
+          <div className="welcome__quality__content">
+            <Text content={content2} type="main-content" />
+          </div>
+        </div>
       </div>
       <div className="welcome__button-group">
         <Button

--- a/src/pages/MainLayout.tsx
+++ b/src/pages/MainLayout.tsx
@@ -5,11 +5,13 @@ import { Outlet, useLocation } from 'react-router-dom';
 
 const MainLayout = () => {
   const location = useLocation();
+  const hideHeaderFooterPaths = ['/login', '/signup'];
+  const showHeaderFooter = !hideHeaderFooterPaths.includes(location.pathname);
   return (
     <div className="main-layout__container">
-      <Header />
+      {showHeaderFooter && <Header />}
       <Outlet />
-      <Footer />
+      {showHeaderFooter && <Footer />}
     </div>
   );
 };

--- a/src/pages/SignUp.scss
+++ b/src/pages/SignUp.scss
@@ -11,37 +11,31 @@
   }
   &__image {
     background-image: none;
-    width: 900px;
-    height: 600px;
+    width: 45%;
+    height: 55%;
   }
   &__content {
     display: flex;
     flex-direction: column;
-    width: 580px;
-    height: 640px;
+    width: 31%;
     text-align: left;
     justify-content: flex-start;
     border-radius: 50px;
     box-shadow:
       10px 10px 20px $shadow-color,
       -10px -10px 20px $white;
-    margin: 20px;
-    padding-top: 60px;
   }
   &__text-group {
-    margin-bottom: 50px;
-    padding-left: 40px;
+    padding: 50px;
   }
   &__item-group {
     display: flex;
     flex-direction: column;
     align-items: center;
-    margin-bottom: 20px;
   }
   &__input-button-group {
     position: relative;
     margin-bottom: 10px;
-
     button {
       position: absolute;
       right: 5px;
@@ -49,6 +43,6 @@
     }
   }
   &__submit-button {
-    margin-top: 80px;
+    padding: 60px 0 60px 0;
   }
 }

--- a/src/pages/SignUp.scss
+++ b/src/pages/SignUp.scss
@@ -43,6 +43,6 @@
     }
   }
   &__submit-button {
-    padding: 60px 0 60px 0;
+    padding: 60px 0;
   }
 }


### PR DESCRIPTION
## #️⃣ Relationship Issues
- close : #24   

<br>

## 💡 Key Changes
- 로그인 회원가입 페이지에서는 헤더와 푸터가 출력되지않게 분기처리하였습니다.
![image](https://github.com/user-attachments/assets/8ce6af95-3cbb-40ef-8c33-b6a00f51f3c3)
- 헤더와 푸터 디자인 수정을 진행하였습니다, 헤더의 경우 스크롤을 내려도 같이 이동됩니다.
![image](https://github.com/user-attachments/assets/a4e675ab-1939-4eee-a6f6-2c46309e877a)
- 전체적인 css를 수정하였습니다. padding의 경우 상,하만 주도록 처리하고 좌우는 width로 최대한 처리하였습니다.
- text 인터페이스의 속성에 타입,색상 2개씩 추가하였습니다.
- 회사 등록 시 정규식으로 이메일 형식, 사업자 번호 예외 메세지 추가 진행하였습니다. 
![image](https://github.com/user-attachments/assets/af7680fa-33c9-456b-83fc-c052a92eb00f)



<br>

## ➕ ETC 
> 초기 회사 검색은 mui dropdown으로 api 연결과 같이 진행할 예정입니다.
